### PR TITLE
Referl diagnostics no retry no logic

### DIFF
--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -66,32 +66,31 @@ source() ->
 %% Internal Functions
 %%==============================================================================
 
-% ddoocc
+% @doc
 % Returns the enabled diagnostic aliases from config
-%-spec configured_diagnostics() -> sets:set().
-%configured_diagnostics() ->
-%  case els_config:get(refactorerl) of
-%    #{"diagnostics" := List} ->
-%      sets:from_list(List);
-%    _ ->
-%      []
-%  end.
+-spec configured_diagnostics() -> sets:set().
+configured_diagnostics() ->
+  case els_config:get(refactorerl) of
+    #{"diagnostics" := List} ->
+      AtomList = [list_to_atom(Element) || Element <- List],
+      sets:from_list(AtomList);
+    _ ->
+      []
+  end.
 
-% ddoocc
+% @doc
 % Returns the default diagnostic aliases
-%-spec default_diagnostics() -> sets:set().
-%default_diagnostics() ->
-%  sets:from_list(["unused_macros", "unsecure_os_call"]).
+-spec default_diagnostics() -> sets:set().
+default_diagnostics() ->
+  sets:from_list([unused_macros, unsecure_os_call]).
 
 
 % @doc
 % Returns the enabled diagnostics by merging default and configed
 -spec enabled_diagnostics() -> [refactorerl_diagnostic_alias()].
 enabled_diagnostics() ->
-  %Set = sets:union(default_diagnostics(), configured_diagnostics()),
-  %sets:to_list(Set), %TODO Set operation
-  %["unused_macros", "unsecure_os_call"].
-  [unused_macros, unsecure_os_call].
+  Set = sets:union(default_diagnostics(), configured_diagnostics()),
+  sets:to_list(Set).
 
 
 % @doc

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -34,7 +34,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-  false.
+  true.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
@@ -42,20 +42,21 @@ run(Uri) ->
     <<".erl">> ->
       case els_refactorerl_utils:referl_node() of
         {error, _} ->
-          [];
+          ["error2"];
         {ok, _} ->
           case els_refactorerl_utils:add(Uri) of
             error ->
-              [];
+              ["error1"];
             ok ->
               Module = els_uri:module(Uri),
               Diags = enabled_diagnostics(),
               Results = els_refactorerl_utils:run_diagnostics(Diags, Module),
-              make_diagnostics(Results)
+              make_diagnostics(Results),
+              ["alma"]
           end
       end;
     _ ->
-      []
+      ["korte"]
   end.
 
 -spec source() -> binary().

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -77,7 +77,7 @@ source() ->
 %      []
 %  end.
 
-% @doc
+% ddoocc
 % Returns the default diagnostic aliases
 %-spec default_diagnostics() -> sets:set().
 %default_diagnostics() ->

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -38,25 +38,29 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
+  %TODO TEST
+  io:format(">>>>>> Diagnostics begin"),
   case filename:extension(Uri) of
     <<".erl">> ->
       case els_refactorerl_utils:referl_node() of
         {error, _} ->
-          ["error2"];
+          [];
         {ok, _} ->
           case els_refactorerl_utils:add(Uri) of
             error ->
-              ["error1"];
+              [];
             ok ->
               Module = els_uri:module(Uri),
               Diags = enabled_diagnostics(),
               Results = els_refactorerl_utils:run_diagnostics(Diags, Module),
-              make_diagnostics(Results),
-              ["alma"]
+              io:format("Result"),
+              io:format("~p", [Results]),
+              make_diagnostics(Results)
+              
           end
       end;
     _ ->
-      ["korte"]
+      []
   end.
 
 -spec source() -> binary().
@@ -69,28 +73,29 @@ source() ->
 
 % @doc
 % Returns the enabled diagnostic aliases from config
--spec configured_diagnostics() -> sets:set().
-configured_diagnostics() ->
-  case els_config:get(refactorerl) of
-    #{"diagnostics" := List} ->
-      sets:from_list(List);
-    _ ->
-      []
-  end.
+%-spec configured_diagnostics() -> sets:set().
+%configured_diagnostics() ->
+%  case els_config:get(refactorerl) of
+%    #{"diagnostics" := List} ->
+%      sets:from_list(List);
+%    _ ->
+%      []
+%  end.
 
 % @doc
 % Returns the default diagnostic aliases
--spec default_diagnostics() -> sets:set().
-default_diagnostics() ->
-  sets:from_list(["unused_macros", "unsecure_os_calls"]).
+%-spec default_diagnostics() -> sets:set().
+%default_diagnostics() ->
+%  sets:from_list(["unused_macros", "unsecure_os_calls"]).
 
 
 % @doc
 % Returns the enabled diagnostics by merging default and configed
 -spec enabled_diagnostics() -> [refactorerl_diagnostic_alias()].
 enabled_diagnostics() ->
-  Set = sets:union(default_diagnostics(), configured_diagnostics()),
-  sets:to_list(Set).
+  %Set = sets:union(default_diagnostics(), configured_diagnostics()),
+  %sets:to_list(Set), %TODO Set operation
+  ["unused_macros", "unsecure_os_calls"].
 
 
 % @doc

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -65,7 +65,7 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
-%% 
+
 % @doc
 % Returns the enabled diagnostic aliases from config
 -spec configured_diagnostics() -> sets:set().
@@ -78,14 +78,14 @@ configured_diagnostics() ->
   end.
 
 % @doc
-% Returns the default diagnostic aliases 
+% Returns the default diagnostic aliases
 -spec default_diagnostics() -> sets:set().
 default_diagnostics() ->
-  ets:from_list(["unused_macros", "unsecure_os_calls"]).
+  sets:from_list(["unused_macros", "unsecure_os_calls"]).
 
 
 % @doc
-% Returns the enabled diagnostics by merging default and configed 
+% Returns the enabled diagnostics by merging default and configed
 -spec enabled_diagnostics() -> [refactorerl_diagnostic_alias()].
 enabled_diagnostics() ->
   Set = sets:union(default_diagnostics(), configured_diagnostics()),

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -24,7 +24,7 @@
 %%==============================================================================
 %% Types
 %%==============================================================================
--type refactorerl_diagnostic_alias() :: string().
+-type refactorerl_diagnostic_alias() :: atom().
 -type refactorerl_diagnostic_result() :: {range(), string()}.
 %-type refactorerl_query() :: [char()].
 
@@ -52,7 +52,6 @@ run(Uri) ->
               Diags = enabled_diagnostics(),
               Results = els_refactorerl_utils:run_diagnostics(Diags, Module),
               make_diagnostics(Results)
-              
           end
       end;
     _ ->

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -66,7 +66,7 @@ source() ->
 %% Internal Functions
 %%==============================================================================
 
-% @doc
+% ddoocc
 % Returns the enabled diagnostic aliases from config
 %-spec configured_diagnostics() -> sets:set().
 %configured_diagnostics() ->

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -34,7 +34,7 @@
 
 -spec is_default() -> boolean().
 is_default() ->
-  true.
+  false.
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -38,8 +38,6 @@ is_default() ->
 
 -spec run(uri()) -> [els_diagnostics:diagnostic()].
 run(Uri) ->
-  %TODO TEST
-  io:format(">>>>>> Diagnostics begin"),
   case filename:extension(Uri) of
     <<".erl">> ->
       case els_refactorerl_utils:referl_node() of
@@ -53,8 +51,6 @@ run(Uri) ->
               Module = els_uri:module(Uri),
               Diags = enabled_diagnostics(),
               Results = els_refactorerl_utils:run_diagnostics(Diags, Module),
-              io:format("Result"),
-              io:format("~p", [Results]),
               make_diagnostics(Results)
               
           end
@@ -86,7 +82,7 @@ source() ->
 % Returns the default diagnostic aliases
 %-spec default_diagnostics() -> sets:set().
 %default_diagnostics() ->
-%  sets:from_list(["unused_macros", "unsecure_os_calls"]).
+%  sets:from_list(["unused_macros", "unsecure_os_call"]).
 
 
 % @doc
@@ -95,7 +91,8 @@ source() ->
 enabled_diagnostics() ->
   %Set = sets:union(default_diagnostics(), configured_diagnostics()),
   %sets:to_list(Set), %TODO Set operation
-  ["unused_macros", "unsecure_os_calls"].
+  %["unused_macros", "unsecure_os_call"].
+  [unused_macros, unsecure_os_call].
 
 
 % @doc

--- a/apps/els_lsp/src/els_refactorerl_diagnostics.erl
+++ b/apps/els_lsp/src/els_refactorerl_diagnostics.erl
@@ -65,32 +65,16 @@ source() ->
 %%==============================================================================
 %% Internal Functions
 %%==============================================================================
-
-% @doc
-% Returns the enabled diagnostic aliases from config
--spec configured_diagnostics() -> sets:set().
-configured_diagnostics() ->
-  case els_config:get(refactorerl) of
-    #{"diagnostics" := List} ->
-      AtomList = [list_to_atom(Element) || Element <- List],
-      sets:from_list(AtomList);
-    _ ->
-      []
-  end.
-
-% @doc
-% Returns the default diagnostic aliases
--spec default_diagnostics() -> sets:set().
-default_diagnostics() ->
-  sets:from_list([unused_macros, unsecure_os_call]).
-
-
 % @doc
 % Returns the enabled diagnostics by merging default and configed
 -spec enabled_diagnostics() -> [refactorerl_diagnostic_alias()].
 enabled_diagnostics() ->
-  Set = sets:union(default_diagnostics(), configured_diagnostics()),
-  sets:to_list(Set).
+  case els_config:get(refactorerl) of
+    #{"diagnostics" := List} ->
+      [list_to_atom(Element) || Element <- List];
+    _ ->
+      []
+  end.
 
 
 % @doc

--- a/apps/els_lsp/src/els_refactorerl_utils.erl
+++ b/apps/els_lsp/src/els_refactorerl_utils.erl
@@ -92,11 +92,12 @@ add(Uri) ->
 
 %%@doc
 %% Runs list of diagnostic aliases on refactorerl
--spec run_diagnostics(list(), atom()) -> list(). 
+-spec run_diagnostics(list(), atom()) -> list().
 run_diagnostics(DiagnosticAliases, Module) ->
   case els_refactorerl_utils:referl_node() of
     {ok, Node} ->
-      rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]); %% returns error | ok
+      %% returns error | ok
+      rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]);
     _ -> % In this case there was probably error.
       []
   end.
@@ -121,7 +122,7 @@ notification(Msg) ->
 %% Checks if the given node is running RefactorErl with ELS interface
 -spec is_refactorerl(atom()) -> boolean().
 is_refactorerl(Node) ->
-  case pc:call(Node, referl_els, ping, [], 500) of
+  case rpc:call(Node, referl_els, ping, [], 500) of
     {refactorerl_els, pong} -> true;
     _ -> false
   end.

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -127,7 +127,7 @@ init_per_testcase(TestCase, Config) when TestCase =:= gradualizer ->
 
 % RefactorErl
 init_per_testcase(TestCase, Config) when TestCase =:= unused_macros_refactorerl ->
-  io:format("INIT"),
+  mock_refactorerl(),
   els_test_utils:init_per_testcase(TestCase, Config);
 
 init_per_testcase(TestCase, Config) ->
@@ -171,10 +171,18 @@ end_per_testcase(TestCase, Config) when TestCase =:= gradualizer ->
   els_test_utils:end_per_testcase(TestCase, Config),
   els_mock_diagnostics:teardown(),
   ok;
+end_per_testcase(TestCase, Config) 
+  when TestCase =:= unused_macros_refactorerl ->
+  unmock_refactoerl(),
+  els_test_utils:end_per_testcase(TestCase, Config),
+  els_mock_diagnostics:teardown(); 
 end_per_testcase(TestCase, Config) ->
   els_test_utils:end_per_testcase(TestCase, Config),
   els_mock_diagnostics:teardown(),
   ok.
+
+% RefactorErl
+
 
 %%==============================================================================
 %% Testcases
@@ -752,3 +760,83 @@ src_path(Module) ->
 
 include_path(Header) ->
   filename:join(["code_navigation", "include", Header]).
+
+
+% Mock RefactorErl utils
+mock_refactorerl() ->
+  %meck:new(rpc, [passthrough, no_link, unstick]),
+  %{ok, HostName} = inet:gethostname(),
+  %NodeName = list_to_atom("fakenode@" ++ HostName),
+  %meck:expect( rpc
+  %           , call
+  %           , fun(PNode, c, c, [Module]) when PNode =:= NodeName ->
+  %                 {ok, Module};
+  %                (Node, Mod, Fun, Args) ->
+  %                 meck:passthrough([Node, Mod, Fun, Args])
+  %             end
+  %           ).
+  meck:new(els_refactorerl_utils),
+  {ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+  meck:expect(els_refactorerl_utils, run_diagnostics, 2, ["Hello"]),
+  meck:expect(els_refactorerl_utils, referl_node, 0, {ok, NodeName}),
+  meck:expect(els_refactorerl_utils, add, 1, ok),
+  % 
+  
+
+   
+  % rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]);
+  meck:new(rpc, [passthrough, no_link, unstick]),
+  {ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+  meck:expect( rpc
+             , call
+             , fun(_RPCNode, referl_els, run_diagnostics, [_DiagnosticAliases, _Module]) -> %{ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+              [{#{'end' => #{character => 12,line => 16},
+              start => #{character => 4,line => 16}},
+              <<"Unsecure OS call: os:cmd(A)">>},
+             {#{'end' => #{character => 35,line => 5},
+                start => #{character => 0,line => 5}},
+              <<"Unused macros: UNUSED_MACRO">>},
+             {#{'end' => #{character => 36,line => 6},
+                start => #{character => 0,line => 6}},
+              <<"Unused macros: UNUSED_MACRO_WITH_ARG">>}]   
+              %;
+              %(Node, Mod, Fun, Args) ->
+              %     meck:passthrough([Node, Mod, Fun, Args])
+               end
+             ),
+  
+  
+  % rpc:call(Node, referl_els, add, [Path]); %% returns error | ok
+  %meck:new(rpc, [passthrough, no_link, unstick]),
+  {ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+  meck:expect( rpc
+             , call
+             , fun(_RPCNode, referl_els, add, [_Path]) -> %{ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+                ok%;
+              %(Node, Mod, Fun, Args) ->
+              %     meck:passthrough([Node, Mod, Fun, Args])
+               end
+             ),
+  
+  % rpc:call(Node, referl_els, ping, [], 500)
+  %meck:new(rpc, [passthrough, no_link, unstick]),
+  {ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+  meck:expect( rpc
+             , call
+             , fun(_RPCNode, referl_els, ping, [], 500) -> %{ok, HostName} = inet:gethostname(),
+  NodeName = list_to_atom("referl_fake@" ++ HostName),
+                {refactorerl_els, pong}%;
+              %(Node, Mod, Fun, Args) ->
+              %     meck:passthrough([Node, Mod, Fun, Args])
+               end
+             ). 
+
+unmock_refactoerl() ->
+  meck:unload(rpc),
+  meck:unload(refactorerl_els).

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -175,7 +175,8 @@ end_per_testcase(TestCase, Config)
   when TestCase =:= unused_macros_refactorerl ->
   unmock_refactoerl(),
   els_test_utils:end_per_testcase(TestCase, Config),
-  els_mock_diagnostics:teardown(); 
+  els_mock_diagnostics:teardown(),
+  ok;
 end_per_testcase(TestCase, Config) ->
   els_test_utils:end_per_testcase(TestCase, Config),
   els_mock_diagnostics:teardown(),
@@ -763,80 +764,69 @@ include_path(Header) ->
 
 
 % Mock RefactorErl utils
-mock_refactorerl() ->
-  %meck:new(rpc, [passthrough, no_link, unstick]),
-  %{ok, HostName} = inet:gethostname(),
-  %NodeName = list_to_atom("fakenode@" ++ HostName),
-  %meck:expect( rpc
-  %           , call
-  %           , fun(PNode, c, c, [Module]) when PNode =:= NodeName ->
-  %                 {ok, Module};
-  %                (Node, Mod, Fun, Args) ->
-  %                 meck:passthrough([Node, Mod, Fun, Args])
-  %             end
-  %           ).
-  meck:new(els_refactorerl_utils),
+mock_refactorerl() -> 
   {ok, HostName} = inet:gethostname(),
   NodeName = list_to_atom("referl_fake@" ++ HostName),
-  meck:expect(els_refactorerl_utils, run_diagnostics, 2, ["Hello"]),
+
+  meck:new(els_refactorerl_utils, [passthrough, no_link, unstick]),
+  meck:expect(els_refactorerl_utils, run_diagnostics, 2, [{#{'end' => #{character => 12,line => 16},
+             start => #{character => 4,line => 16}},
+              <<"Unsecure OS call: os:cmd(A)">>}]),
   meck:expect(els_refactorerl_utils, referl_node, 0, {ok, NodeName}),
   meck:expect(els_refactorerl_utils, add, 1, ok),
-  % 
-  
+  meck:expect(els_refactorerl_utils, source_name, 0, <<"RefactorErl">>),
 
-   
-  % rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]);
+  
+  %rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]);
   meck:new(rpc, [passthrough, no_link, unstick]),
-  {ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
   meck:expect( rpc
              , call
-             , fun(_RPCNode, referl_els, run_diagnostics, [_DiagnosticAliases, _Module]) -> %{ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
-              [{#{'end' => #{character => 12,line => 16},
-              start => #{character => 4,line => 16}},
-              <<"Unsecure OS call: os:cmd(A)">>},
-             {#{'end' => #{character => 35,line => 5},
+             , fun(Node, referl_els, run_diagnostics, [_DiagnosticAliases, _Module]) when Node =:= NodeName ->
+             io:format("RunDiag"),
+              [{#{'end' => #{character => 35,line => 5},
                 start => #{character => 0,line => 5}},
               <<"Unused macros: UNUSED_MACRO">>},
              {#{'end' => #{character => 36,line => 6},
                 start => #{character => 0,line => 6}},
-              <<"Unused macros: UNUSED_MACRO_WITH_ARG">>}]   
+              <<"Unused macros: UNUSED_MACRO_WITH_ARG">>}]  ; 
               %;
-              %(Node, Mod, Fun, Args) ->
-              %     meck:passthrough([Node, Mod, Fun, Args])
+              (Node, Mod, Fun, Args) ->
+                   meck:passthrough([Node, Mod, Fun, Args])
                end
              ),
-  
-  
-  % rpc:call(Node, referl_els, add, [Path]); %% returns error | ok
+
+
+  %rpc:call(Node, referl_els, add, [Path]); %% returns error | ok
   %meck:new(rpc, [passthrough, no_link, unstick]),
-  {ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
   meck:expect( rpc
-             , call
-             , fun(_RPCNode, referl_els, add, [_Path]) -> %{ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
-                ok%;
-              %(Node, Mod, Fun, Args) ->
-              %     meck:passthrough([Node, Mod, Fun, Args])
-               end
-             ),
+            , call
+            , fun(_RPCNode, referl_els, add, [_Path]) -> %{ok, HostName} = inet:gethostname(),
+            io:format("Add"),
+
+               ok;
+             
+             (Node, Mod, Fun, Args) ->
+                  meck:passthrough([Node, Mod, Fun, Args])
+              end
+            ),
   
   % rpc:call(Node, referl_els, ping, [], 500)
   %meck:new(rpc, [passthrough, no_link, unstick]),
-  {ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
+  % 
+  
   meck:expect( rpc
-             , call
-             , fun(_RPCNode, referl_els, ping, [], 500) -> %{ok, HostName} = inet:gethostname(),
-  NodeName = list_to_atom("referl_fake@" ++ HostName),
-                {refactorerl_els, pong}%;
-              %(Node, Mod, Fun, Args) ->
-              %     meck:passthrough([Node, Mod, Fun, Args])
-               end
-             ). 
+  , call
+  , fun(_RPCNode, referl_els, ping, ["_Path"]) -> %{ok, HostName} = inet:gethostname(),
+  io:format("Ping"),
+
+  {refactorerl_els, pong};
+   
+   (Node, Mod, Fun, Args) ->
+        meck:passthrough([Node, Mod, Fun, Args])
+    end
+  ).
+   
 
 unmock_refactoerl() ->
-  meck:unload(rpc),
-  meck:unload(refactorerl_els).
+  meck:unload(rpc).
+  %meck:unload(els_refactorerl_utils).

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -679,10 +679,10 @@ unused_macros_refactorerl(_Config) ->
   Source = <<"RefactorErl">>,
   Errors = [],
   Warnings = [ #{ message => <<"Unused macro: UNUSED_MACRO">>
-                , range => {{5, 8}, {5, 20}}
+                , range => {{5, 0}, {5, 35}}
                 },
-               #{ message => <<"Unused macro: UNUSED_MACRO_WITH_ARG/1">>
-                , range => {{6, 8}, {6, 29}}
+               #{ message => <<"Unused macro: UNUSED_MACRO_WITH_ARG">>
+                , range => {{6, 0}, {6, 36}}
                 }
              ],
   Hints = [],
@@ -769,64 +769,18 @@ mock_refactorerl() ->
   NodeName = list_to_atom("referl_fake@" ++ HostName),
 
   meck:new(els_refactorerl_utils, [passthrough, no_link, unstick]),
-  meck:expect(els_refactorerl_utils, run_diagnostics, 2, [{#{'end' => #{character => 12,line => 16},
-             start => #{character => 4,line => 16}},
-              <<"Unsecure OS call: os:cmd(A)">>}]),
+  meck:expect(els_refactorerl_utils, run_diagnostics, 2, 
+    [ {# {'end' => #{character => 35,line => 5},
+          start => #{character => 0,line => 5}},
+        <<"Unused macro: UNUSED_MACRO">>},
+      {# {'end' => #{character => 36,line => 6},
+           start => #{character => 0,line => 6}},
+        <<"Unused macro: UNUSED_MACRO_WITH_ARG">>}] 
+      ),
   meck:expect(els_refactorerl_utils, referl_node, 0, {ok, NodeName}),
   meck:expect(els_refactorerl_utils, add, 1, ok),
-  meck:expect(els_refactorerl_utils, source_name, 0, <<"RefactorErl">>),
+  meck:expect(els_refactorerl_utils, source_name, 0, <<"RefactorErl">>).
 
-  
-  %rpc:call(Node, referl_els, run_diagnostics, [DiagnosticAliases, Module]);
-  meck:new(rpc, [passthrough, no_link, unstick]),
-  meck:expect( rpc
-             , call
-             , fun(Node, referl_els, run_diagnostics, [_DiagnosticAliases, _Module]) when Node =:= NodeName ->
-             io:format("RunDiag"),
-              [{#{'end' => #{character => 35,line => 5},
-                start => #{character => 0,line => 5}},
-              <<"Unused macros: UNUSED_MACRO">>},
-             {#{'end' => #{character => 36,line => 6},
-                start => #{character => 0,line => 6}},
-              <<"Unused macros: UNUSED_MACRO_WITH_ARG">>}]  ; 
-              %;
-              (Node, Mod, Fun, Args) ->
-                   meck:passthrough([Node, Mod, Fun, Args])
-               end
-             ),
-
-
-  %rpc:call(Node, referl_els, add, [Path]); %% returns error | ok
-  %meck:new(rpc, [passthrough, no_link, unstick]),
-  meck:expect( rpc
-            , call
-            , fun(_RPCNode, referl_els, add, [_Path]) -> %{ok, HostName} = inet:gethostname(),
-            io:format("Add"),
-
-               ok;
-             
-             (Node, Mod, Fun, Args) ->
-                  meck:passthrough([Node, Mod, Fun, Args])
-              end
-            ),
-  
-  % rpc:call(Node, referl_els, ping, [], 500)
-  %meck:new(rpc, [passthrough, no_link, unstick]),
-  % 
-  
-  meck:expect( rpc
-  , call
-  , fun(_RPCNode, referl_els, ping, ["_Path"]) -> %{ok, HostName} = inet:gethostname(),
-  io:format("Ping"),
-
-  {refactorerl_els, pong};
-   
-   (Node, Mod, Fun, Args) ->
-        meck:passthrough([Node, Mod, Fun, Args])
-    end
-  ).
-   
 
 unmock_refactoerl() ->
-  meck:unload(rpc).
-  %meck:unload(els_refactorerl_utils).
+  meck:unload(els_refactorerl_utils).

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -39,6 +39,7 @@
         , unused_includes_compiler_attribute/1
         , exclude_unused_includes/1
         , unused_macros/1
+        , unused_macros_refactorerl/1
         , unused_record_fields/1
         , gradualizer/1
         ]).
@@ -123,6 +124,12 @@ init_per_testcase(TestCase, Config) when TestCase =:= gradualizer ->
   meck:expect(els_gradualizer_diagnostics, is_default, 0, true),
   els_mock_diagnostics:setup(),
   els_test_utils:init_per_testcase(TestCase, Config);
+
+% RefactorErl
+init_per_testcase(TestCase, Config) when TestCase =:= unused_macros_refactorerl ->
+  io:format("INIT"),
+  els_test_utils:init_per_testcase(TestCase, Config);
+
 init_per_testcase(TestCase, Config) ->
   els_mock_diagnostics:setup(),
   els_test_utils:init_per_testcase(TestCase, Config).
@@ -650,6 +657,24 @@ gradualizer(_Config) ->
                     <<"The variable N is expected to have type integer() "
                       "but it has type false | true\n">>
                 , range => {{10, 0}, {11, 0}}}
+             ],
+  Hints = [],
+  els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).
+
+
+
+% RefactorErl test cases
+-spec unused_macros_refactorerl(config()) -> ok.
+unused_macros_refactorerl(_Config) ->
+  Path = src_path("diagnostics_unused_macros.erl"),
+  Source = <<"RefactorErl">>,
+  Errors = [],
+  Warnings = [ #{ message => <<"Unused macro: UNUSED_MACRO">>
+                , range => {{5, 8}, {5, 20}}
+                },
+               #{ message => <<"Unused macro: UNUSED_MACRO_WITH_ARG/1">>
+                , range => {{6, 8}, {6, 29}}
+                }
              ],
   Hints = [],
   els_test:run_diagnostics_test(Path, Source, Errors, Warnings, Hints).

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -779,8 +779,12 @@ mock_refactorerl() ->
       ),
   meck:expect(els_refactorerl_utils, referl_node, 0, {ok, NodeName}),
   meck:expect(els_refactorerl_utils, add, 1, ok),
-  meck:expect(els_refactorerl_utils, source_name, 0, <<"RefactorErl">>).
+  meck:expect(els_refactorerl_utils, source_name, 0, <<"RefactorErl">>),
+
+  meck:new(els_refactorerl_diagnostics, [passthrough, no_link, unstick]),
+  meck:expect(els_refactorerl_diagnostics, is_default, 0, true).
 
 
 unmock_refactoerl() ->
+  meck:unload(els_refactorerl_diagnostics),
   meck:unload(els_refactorerl_utils).

--- a/apps/els_lsp/test/els_diagnostics_SUITE.erl
+++ b/apps/els_lsp/test/els_diagnostics_SUITE.erl
@@ -126,7 +126,8 @@ init_per_testcase(TestCase, Config) when TestCase =:= gradualizer ->
   els_test_utils:init_per_testcase(TestCase, Config);
 
 % RefactorErl
-init_per_testcase(TestCase, Config) when TestCase =:= unused_macros_refactorerl ->
+init_per_testcase(TestCase, Config)
+                       when TestCase =:= unused_macros_refactorerl ->
   mock_refactorerl(),
   els_test_utils:init_per_testcase(TestCase, Config);
 
@@ -171,7 +172,7 @@ end_per_testcase(TestCase, Config) when TestCase =:= gradualizer ->
   els_test_utils:end_per_testcase(TestCase, Config),
   els_mock_diagnostics:teardown(),
   ok;
-end_per_testcase(TestCase, Config) 
+end_per_testcase(TestCase, Config)
   when TestCase =:= unused_macros_refactorerl ->
   unmock_refactoerl(),
   els_test_utils:end_per_testcase(TestCase, Config),
@@ -762,20 +763,19 @@ src_path(Module) ->
 include_path(Header) ->
   filename:join(["code_navigation", "include", Header]).
 
-
 % Mock RefactorErl utils
-mock_refactorerl() -> 
+mock_refactorerl() ->
   {ok, HostName} = inet:gethostname(),
   NodeName = list_to_atom("referl_fake@" ++ HostName),
 
   meck:new(els_refactorerl_utils, [passthrough, no_link, unstick]),
-  meck:expect(els_refactorerl_utils, run_diagnostics, 2, 
-    [ {# {'end' => #{character => 35,line => 5},
-          start => #{character => 0,line => 5}},
+  meck:expect(els_refactorerl_utils, run_diagnostics, 2,
+    [ {# {'end' => #{character => 35, line => 5},
+          start => #{character => 0, line => 5}},
         <<"Unused macro: UNUSED_MACRO">>},
-      {# {'end' => #{character => 36,line => 6},
-           start => #{character => 0,line => 6}},
-        <<"Unused macro: UNUSED_MACRO_WITH_ARG">>}] 
+      {# {'end' => #{character => 36, line => 6},
+           start => #{character => 0, line => 6}},
+        <<"Unused macro: UNUSED_MACRO_WITH_ARG">>}]
       ),
   meck:expect(els_refactorerl_utils, referl_node, 0, {ok, NodeName}),
   meck:expect(els_refactorerl_utils, add, 1, ok),


### PR DESCRIPTION
### Tests & Logic moved to RefactorErl side

- I added tests that cover the communication / interace module for RefactorErl
- Most of the logic was moved outside ELS to RefactorErl 
- The remaining logic is well documented in the code

**Some thing to note:**

-  The current release of RefactorErl **cannot** communicate with ELS as, the interface module is not present, but it will be in the next release
